### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v1.2.7
+  - Changed so Advanced Media Extensions and Media Server don't need to be uninstalled after DSM update.
+    - Now starts already installed Advanced Media Extensions and Media Server if they aren't running.
+
 v1.1.6
   - Now installs a version of Media Server that supports video and audio conversion.
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Script to install Video Station in DSM 7.2.2
 
 Synology's Video Station package has been installed more than 66 million times so there are a lot people very annoyed that Synology decided to abandon Video Station when DSM 7.2.2 was released. Many of those people are saying they will never buy another Synology NAS. So I decided to make it possible to install Video Station in DSM 7.2.2 for people who really want Video Station.
 
-This script installs Video Station 3.1.0-3153 and Codec Pack 3.1.0-3005
+This script installs Video Station 3.1.0-3153 and Advanced Media Extensions 3.1.0-3005
 
 Now also installs Media Server 2.1.0-3304 which supports video and audio conversion.
 
-After running this script and enabling HEVC decoding in Advanced Media Extensions Synology Photos will be able to create thumbnails for HEIC photos again.
+**HEIC for Synology Photos:** After running this script and enabling HEVC decoding in Advanced Media Extensions Synology Photos will be able to create thumbnails for HEIC photos again (you can then uninstall Video Station and/or Media Server if you don't need them).
 
 **<p align="center">Video Station installed in DSM 7.2.2</p>**
 <!-- <p align="center"><img src="/images/installed-1.png"></p> -->
@@ -69,3 +69,21 @@ Finally run VideoStation-FFMPEG-Patcher with the `-v 6` option:
 ```YAML
 sudo -s /volume1/scripts/VideoStation-FFMPEG-Patcher/patcher.sh -v 6
 ```
+
+### What about future DSM updates?
+
+***With Video Station installed:***
+
+1. You'll get a message saying Video Station needs to be uninstalled before updating DSM.
+2. Uninstall Video Station (but do ***not** tick the box to delete Video Station's database).
+3. Update DSM.
+4. Package Center will show Advanced Media Extensions and Media Server as "incompatible with your DSM".
+5. Run this script again.
+
+***Without Video Station installed:***
+
+1. Update DSM.
+2. Package Center will show Advanced Media Extensions and Media Server as "incompatible with your DSM".
+3. Run this script again.
+
+</br>

--- a/videostation_for_722.sh
+++ b/videostation_for_722.sh
@@ -11,7 +11,7 @@
 # https://web.archive.org/web/20240825163306/https://archive.synology.com/download/Package
 #------------------------------------------------------------------------------
 # To get Video Station to work I needed to install an older version of AME...
-# which means Drive, Photos and Surveillance Station won't work
+# which means Drive and Surveillance Station may not work
 # (unless I install older versions of them).
 #------------------------------------------------------------------------------
 # I've seen evidence of:
@@ -27,7 +27,7 @@
 #   or add OpenSubtitle changes from 3.1.1-3168 to 3.1.0-3153
 #------------------------------------------------------------------------------
 
-scriptver="v1.1.6"
+scriptver="v1.2.7"
 script=Video_Station_for_DSM_722
 repo="007revad/Video_Station_for_DSM_722"
 scriptname=videostation_for_722
@@ -191,7 +191,7 @@ if ! printf "%s\n%s\n" "$tag" "$scriptver" |
 
                             # Copy new CHANGES.txt file to script location (if script on a volume)
                             if [[ $scriptpath =~ /volume* ]]; then
-                                # Set permsissions on CHANGES.txt
+                                # Set permissions on CHANGES.txt
                                 if ! chmod 664 "/tmp/$script-$shorttag/CHANGES.txt"; then
                                     permerr=1
                                     echo -e "${Error}ERROR${Off} Failed to set permissions on:"
@@ -529,6 +529,23 @@ if ! check_pkg_installed MediaServer && [[ $ame_version != "20.1.0-3304" ]]; the
     rm -f "/tmp/MediaServer-${cputype}-2.1.0-3304.spk"
 else
     echo -e "\n${Cyan}Media Server${Off} already installed"
+fi
+
+# Start packages if needed (i.e. after DSM update)
+if check_pkg_installed CodecPack; then
+    if ! package_is_running CodecPack; then
+        package_start CodecPack "Advanced Media Extensions"
+    fi
+fi
+if check_pkg_installed VideoStation; then
+    if ! package_is_running VideoStation; then
+        package_start VideoStation "Video Station"
+    fi
+fi
+if check_pkg_installed MediaServer; then
+    if ! package_is_running MediaServer; then
+        package_start MediaServer "Media Server"
+    fi
 fi
 
 echo -e "\nFinished :)"


### PR DESCRIPTION
v1.2.7
  - Changed so Advanced Media Extensions and Media Server don't need to be uninstalled after DSM update.
    - Now starts already installed Advanced Media Extensions and Media Server if they aren't running.