### PR TITLE
Develop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@ v1.3.17
 - Changed to install the latest DSM 7.1 Media Server 2.0.5-3152 as it is not affected by Synology-SA-24:28
   - https://www.synology.com/en-uk/security/advisory/Synology_SA_24_28
   - https://www.cve.org/CVERecord?id=CVE-2024-4464
-- Now shows which Media Server is installed.
+- Now shows which Media Server version is installed.
 - Bug fix for always re-installing Media Server even if correct version was already installed.
 - Bug fix for not updating Video Station or Media Server if old version was already installed by this script.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,10 @@
 v1.3.17
-- Now shows which Media Server is installed.
-
-v1.3.16
 - Changed to install the latest DSM 7.1 Media Server 2.0.5-3152 as it is not affected by Synology-SA-24:28
   - https://www.synology.com/en-uk/security/advisory/Synology_SA_24_28
   - https://www.cve.org/CVERecord?id=CVE-2024-4464
+- Now shows which Media Server is installed.
 - Bug fix for always re-installing Media Server even if correct version was already installed.
+- Bug fix for not updating Video Station or Media Server if old version was already installed by this script.
 
 v1.3.15
 - Added support for Alpine and Alpine4K (DS1817, DS1517 and DS416). Issue #49 and #54

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v1.3.17
+- Now shows which Media Server is installed.
+
 v1.3.16
 - Changed to install the latest DSM 7.1 Media Server 2.0.5-3152 as it is not affected by Synology-SA-24:28
   - https://www.synology.com/en-uk/security/advisory/Synology_SA_24_28

--- a/videostation_for_722.sh
+++ b/videostation_for_722.sh
@@ -550,7 +550,8 @@ fi
 # Get installed VideoStation version
 if [[ $no_vs != "yes" ]]; then
     vs_version=$(/usr/syno/bin/synopkg version VideoStation)
-    if check_pkg_installed VideoStation && [[ ${vs_version:0:2} != "30" ]]; then
+    #if check_pkg_installed VideoStation && [[ ${vs_version:0:2} != "30" ]]; then
+    if check_pkg_installed VideoStation && [[ ${vs_version} != "30.1.0-3153" ]]; then
         # Uninstall VideoStation (wrong version)
         echo ""
         package_uninstall VideoStation "Video Station"
@@ -560,7 +561,8 @@ fi
 # Get installed MediaServer version
 if [[ $no_ms != "yes" ]]; then
     ms_version=$(/usr/syno/bin/synopkg version MediaServer)
-    if check_pkg_installed MediaServer && [[ ${ms_version:0:2} != "20" ]]; then
+    #if check_pkg_installed MediaServer && [[ ${ms_version:0:2} != "20" ]]; then
+    if check_pkg_installed MediaServer && [[ ${ms_version} != "20.0.5-3152" ]]; then
         # Uninstall MediaServer (wrong version)
         echo ""
         package_uninstall MediaServer "Media Server"

--- a/videostation_for_722.sh
+++ b/videostation_for_722.sh
@@ -28,7 +28,7 @@
 #   or add OpenSubtitle changes from 3.1.1-3168 to 3.1.0-3153
 #------------------------------------------------------------------------------
 
-scriptver="v1.3.16"
+scriptver="v1.3.17"
 script=Video_Station_for_DSM_722
 repo="007revad/Video_Station_for_DSM_722"
 scriptname=videostation_for_722
@@ -613,7 +613,7 @@ if [[ $no_ms != "yes" ]]; then
         package_start MediaServer "Media Server"
         rm -f "/tmp/MediaServer-${cputype}-2.0.5-3152.spk"
     else
-        echo -e "\n${Cyan}Media Server${Off} already installed"
+        echo -e "\n${Cyan}Media Server${Off} $ms_version already installed"
     fi
 fi
 


### PR DESCRIPTION
v1.3.17
- Changed to install the latest DSM 7.1 Media Server 2.0.5-3152 as it is not affected by Synology-SA-24:28
  - https://www.synology.com/en-uk/security/advisory/Synology_SA_24_28
  - https://www.cve.org/CVERecord?id=CVE-2024-4464
- Now shows which Media Server version is installed.
- Bug fix for always re-installing Media Server even if correct version was already installed.
- Bug fix for not updating Video Station or Media Server if old version was already installed by this script.